### PR TITLE
Fix compilation issues (sketch naming, TimeLib include, duplicate var…

### DIFF
--- a/Roomba-eps8266.ino
+++ b/Roomba-eps8266.ino
@@ -1,5 +1,6 @@
 // Includes
 #include <Time.h>
+#include <TimeLib.h>
 #include <ESP8266mDNS.h>
 #include <ESP8266WiFi.h>
 #include <WiFiClient.h>

--- a/Roombalight/Roombalight.ino
+++ b/Roombalight/Roombalight.ino
@@ -1,5 +1,6 @@
 // Includes
 #include <Time.h>
+#include <TimeLib.h>
 #include <ESP8266mDNS.h>
 #include <ESP8266WiFi.h>
 #include <WiFiClient.h>


### PR DESCRIPTION
These are the changes that I needed to apply still to fix issue #2.

- Arduino IDE doesn't allow for multiple .ino files in one project folder to define the same variables
- The main sketch must match the folder's name
- Compilation was still failing on 1 lacking include (TimeLib)

BTW, the repo name has a typo 'roomba-eps8266' needs to be 'toomba-esp8266'. This I didn't change.

Hope this helps!